### PR TITLE
feat: add autopilot skeleton with backtesting tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Moomoo ChatGPT Trader
 
-ChatGPT-powered trading assistant for U.S. stocks. FastAPI backend and desktop UI built with PyWebview.
-
+ChatGPT-powered trading assistant for U.S. stocks. FastAPI backend and desktop UI now rendered with a small React app (targeting a future Tauri build).
 
 ## Features
 
@@ -28,10 +27,9 @@ Start OpenD gateway, then launch desktop app.
 python desktop-ui/main.py
 ```
 
-
 ## Layout
 - `src/` backend modules
-- `desktop-ui/` PyWebview wrapper and HTML page
+- `desktop-ui/` PyWebview wrapper and React HTML page
 - `requirements.txt` dependencies
 
 4. Start the desktop app (launches the API and UI):
@@ -41,6 +39,6 @@ python desktop-ui/main.py
    ```
 
 ## Roadmap
-- Autopilot mode driven by ChatGPT
-- Natural language commands for settings
+- Autopilot mode driven by ChatGPT (skeleton in place)
+- Natural language commands for settings (basic mapping)
 - Backtesting tab for strategy validation

--- a/desktop-ui/index.html
+++ b/desktop-ui/index.html
@@ -3,61 +3,79 @@
 <head>
   <meta charset="utf-8" />
   <title>Moomoo Trader</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    nav { background:#222; color:#fff; padding:8px; display:flex; gap:8px; }
+    nav button { background:#444; color:#fff; border:none; padding:6px 10px; cursor:pointer; }
+    nav button.active { background:#0080ff; }
+    section { padding:1rem; }
+    input { margin:0.25rem; }
+  </style>
 </head>
 <body>
-  <h1>Bot Dashboard</h1>
-  <section id="mode">
-    <h2>Autonomy Mode</h2>
-    <select id="mode-select"></select>
-  </section>
-  <section id="risk">
-    <h2>Risk Settings</h2>
-    <pre id="risk-json"></pre>
-  </section>
-  <section id="strategies">
-    <h2>Strategies</h2>
-    <ul id="strategy-list"></ul>
-  </section>
-  <section id="log">
-    <h2>Activity Log</h2>
-    <pre id="log-json"></pre>
-  </section>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script>
+    const e = React.createElement;
     const API_BASE = "http://127.0.0.1:8000";
-    async function load() {
-      const modeRes = await fetch(API_BASE + "/bot/mode");
-      const modeData = await modeRes.json();
-      const select = document.getElementById("mode-select");
-      ["assist","semi","auto"].forEach(m => {
-        const opt = document.createElement("option");
-        opt.value = m;
-        opt.textContent = m;
-        if (modeData.mode === m) opt.selected = true;
-        select.appendChild(opt);
-      });
-      select.onchange = async () => {
-        await fetch(API_BASE + "/bot/mode", {
-          method: "PUT",
+
+    function Dashboard() {
+      const [status, setStatus] = React.useState({});
+      const [cmd, setCmd] = React.useState("");
+      React.useEffect(() => { fetch(API_BASE + "/autopilot/status").then(r=>r.json()).then(setStatus); }, []);
+      function send() {
+        fetch(API_BASE + "/command", {
+          method: "POST",
           headers: {"Content-Type": "application/json"},
-          body: JSON.stringify({mode: select.value})
-        });
-      };
-
-      const risk = await (await fetch(API_BASE + "/risk/config")).json();
-      document.getElementById("risk-json").textContent = JSON.stringify(risk, null, 2);
-
-      const strats = await (await fetch(API_BASE + "/automation/strategies")).json();
-      const list = document.getElementById("strategy-list");
-      strats.forEach(s => {
-        const li = document.createElement("li");
-        li.textContent = s.name || ("strategy " + s.id);
-        list.appendChild(li);
-      });
-
-      const log = await (await fetch(API_BASE + "/logs/actions")).json();
-      document.getElementById("log-json").textContent = JSON.stringify(log, null, 2);
+          body: JSON.stringify({text: cmd})
+        }).then(r=>r.json()).then(setStatus);
+        setCmd("");
+      }
+      return e("section", null,
+        e("h2", null, "Autopilot"),
+        e("div", null, "active: " + (status.active ? "yes" : "no")),
+        e("input", {value: cmd, onChange: ev=>setCmd(ev.target.value), placeholder:"command"}),
+        e("button", {onClick: send}, "send")
+      );
     }
-    load();
+
+    function Backtest() {
+      const [symbol, setSymbol] = React.useState("US.AAPL");
+      const [fast, setFast] = React.useState(20);
+      const [slow, setSlow] = React.useState(50);
+      const [res, setRes] = React.useState(null);
+      function run() {
+        fetch(API_BASE + "/backtest/ma-crossover", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({symbol, fast:Number(fast), slow:Number(slow)})
+        }).then(r=>r.json()).then(setRes);
+      }
+      return e("section", null,
+        e("h2", null, "Backtest"),
+        e("div", null,
+          e("input", {value: symbol, onChange:e=>setSymbol(e.target.value)}),
+          e("input", {type:"number", value: fast, onChange:e=>setFast(e.target.value)}),
+          e("input", {type:"number", value: slow, onChange:e=>setSlow(e.target.value)}),
+          e("button", {onClick: run}, "run")
+        ),
+        res && e("pre", null, JSON.stringify(res.metrics, null, 2))
+      );
+    }
+
+    function App() {
+      const [tab, setTab] = React.useState("dash");
+      return e("div", null,
+        e("nav", null,
+          e("button", {className: tab==='dash'?"active":"", onClick:()=>setTab('dash')}, "Dashboard"),
+          e("button", {className: tab==='bt'?"active":"", onClick:()=>setTab('bt')}, "Backtest")
+        ),
+        tab==='dash' ? e(Dashboard) : e(Backtest)
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(e(App));
   </script>
 </body>
 </html>

--- a/src/autopilot.py
+++ b/src/autopilot.py
@@ -1,0 +1,19 @@
+"""Skeleton for autopilot mode."""
+from __future__ import annotations
+
+class Autopilot:
+    """Hold autopilot state."""
+    def __init__(self) -> None:
+        self.active = False
+        self.last_command = ""
+
+    def start(self) -> None:
+        self.active = True
+        self.last_command = "started"
+
+    def stop(self) -> None:
+        self.active = False
+        self.last_command = "stopped"
+
+    def status(self) -> dict:
+        return {"active": self.active, "last_command": self.last_command}

--- a/src/nlp.py
+++ b/src/nlp.py
@@ -1,0 +1,12 @@
+"""Map natural-language commands to actions."""
+from __future__ import annotations
+
+def parse_command(text: str) -> dict:
+    t = text.lower().strip()
+    if "start autopilot" in t:
+        return {"action": "start_autopilot"}
+    if "stop autopilot" in t:
+        return {"action": "stop_autopilot"}
+    if "run backtest" in t:
+        return {"action": "run_backtest"}
+    return {"action": "unknown", "text": text}

--- a/src/server.py
+++ b/src/server.py
@@ -14,6 +14,8 @@ from core.moomoo_client import MoomooClient
 from core.futu_client import TrdEnv
 from core.session import load_session, save_session, clear_session
 from risk.limits import enforce_order_limits
+from autopilot import Autopilot
+from nlp import parse_command
 
 # Optional automation (scheduler + storage + strategy step)
 try:
@@ -79,6 +81,9 @@ client: Optional[MoomooClient] = None
 
 # Global scheduler (if automation imports are available)
 scheduler = None  # will hold TraderScheduler
+
+# Autopilot state holder
+autopilot = Autopilot()
 
 
 # ---------- Risk config (local file) ----------
@@ -215,6 +220,9 @@ class BotModeRequest(BaseModel):
 
 class FlattenAllRequest(BaseModel):
     symbols: Optional[list[str]] = None  # if provided, only flatten these symbols
+
+class CommandRequest(BaseModel):
+    text: str
 
 
 # ---------- Helpers ----------
@@ -667,6 +675,40 @@ def bot_mode_put(req: BotModeRequest):
     set_setting("bot_mode", mode)
     insert_action_log("mode_change", mode=mode, reason="user_update", status="ok")
     return {"mode": mode}
+
+
+# --- Autopilot ---
+
+@app.post("/autopilot/start")
+def autopilot_start():
+    autopilot.start()
+    return autopilot.status()
+
+
+@app.post("/autopilot/stop")
+def autopilot_stop():
+    autopilot.stop()
+    return autopilot.status()
+
+
+@app.get("/autopilot/status")
+def autopilot_status():
+    return autopilot.status()
+
+
+@app.post("/command")
+def command(req: CommandRequest):
+    result = parse_command(req.text)
+    act = result.get("action")
+    if act == "start_autopilot":
+        autopilot.start()
+        return autopilot.status()
+    if act == "stop_autopilot":
+        autopilot.stop()
+        return autopilot.status()
+    if act == "run_backtest":
+        return {"status": "backtest_requested"}
+    raise HTTPException(status_code=400, detail="unknown command")
 
 
 # --- Action Log API ---


### PR DESCRIPTION
## Summary
- add React-based desktop dashboard with backtesting tab
- introduce Autopilot class and natural-language command parser
- expose autopilot endpoints and command mapping in API

## Testing
- `python -m py_compile src/autopilot.py src/nlp.py src/server.py desktop-ui/main.py`
- `pytest`