### PR TITLE
feat: refine dashboard and extend autopilot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Moomoo ChatGPT Trader
 
-ChatGPT-powered trading assistant for U.S. stocks. FastAPI backend and desktop UI built with PyWebview.
-
+ChatGPT-powered trading assistant for U.S. stocks. FastAPI backend and a React desktop UI target a future Tauri build.
 
 ## Features
 
 - Connect to the moomoo API via a local OpenD gateway.
 - Execute a configurable trading strategy (starting with simple moving-average crossovers).
-- Expose a desktop UI for adjusting strategy parameters (e.g., moving-average windows, position sizing, stop-loss).
-- Provide natural-language commands to adjust settings (e.g., "only trade between 9:30 and noon", "tighten stop to 2%").
-- Later, allow the bot to learn and mimic a user's trading style from past trade history (stored locally).
+- Desktop React UI with autopilot controls, backtesting tab, and settings placeholder.
+- Natural-language commands for tasks like starting autopilot or running a backtest.
+- Planned learning mode that mirrors trader style from past history.
 
 ## Setup
 Clone repository and install dependencies.
@@ -28,19 +27,12 @@ Start OpenD gateway, then launch desktop app.
 python desktop-ui/main.py
 ```
 
-
 ## Layout
 - `src/` backend modules
-- `desktop-ui/` PyWebview wrapper and HTML page
+- `desktop-ui/` PyWebview wrapper and React HTML page
 - `requirements.txt` dependencies
-
-4. Start the desktop app (launches the API and UI):
-
-   ```bash
-   python desktop-ui/main.py
-   ```
 
 ## Roadmap
 - Autopilot mode driven by ChatGPT
-- Natural language commands for settings
-- Backtesting tab for strategy validation
+- Rich natural language controls
+- Expanded backtesting and analysis tools

--- a/desktop-ui/index.html
+++ b/desktop-ui/index.html
@@ -3,61 +3,112 @@
 <head>
   <meta charset="utf-8" />
   <title>Moomoo Trader</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin:0; background:#f4f4f7; color:#222; }
+    nav { background:#0d6efd; color:#fff; padding:0.5rem; display:flex; gap:0.5rem; }
+    nav button { background:transparent; border:none; color:#fff; padding:0.5rem 1rem; border-radius:4px; cursor:pointer; }
+    nav button.active { background:rgba(255,255,255,0.2); }
+    section { max-width:800px; margin:1rem auto; background:#fff; padding:1rem; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+    label { display:block; margin-top:0.5rem; font-size:0.9rem; }
+    input { margin-top:0.25rem; padding:0.4rem; }
+    button.primary { background:#0d6efd; color:#fff; border:none; padding:0.5rem 1rem; border-radius:4px; cursor:pointer; }
+    .flex { display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; }
+  </style>
 </head>
 <body>
-  <h1>Bot Dashboard</h1>
-  <section id="mode">
-    <h2>Autonomy Mode</h2>
-    <select id="mode-select"></select>
-  </section>
-  <section id="risk">
-    <h2>Risk Settings</h2>
-    <pre id="risk-json"></pre>
-  </section>
-  <section id="strategies">
-    <h2>Strategies</h2>
-    <ul id="strategy-list"></ul>
-  </section>
-  <section id="log">
-    <h2>Activity Log</h2>
-    <pre id="log-json"></pre>
-  </section>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script>
+    const e = React.createElement;
     const API_BASE = "http://127.0.0.1:8000";
-    async function load() {
-      const modeRes = await fetch(API_BASE + "/bot/mode");
-      const modeData = await modeRes.json();
-      const select = document.getElementById("mode-select");
-      ["assist","semi","auto"].forEach(m => {
-        const opt = document.createElement("option");
-        opt.value = m;
-        opt.textContent = m;
-        if (modeData.mode === m) opt.selected = true;
-        select.appendChild(opt);
-      });
-      select.onchange = async () => {
-        await fetch(API_BASE + "/bot/mode", {
-          method: "PUT",
+
+    function Dashboard() {
+      const [status, setStatus] = React.useState({});
+      const [cmd, setCmd] = React.useState("");
+      const [msg, setMsg] = React.useState("");
+      React.useEffect(() => { refresh(); }, []);
+      function refresh() {
+        fetch(API_BASE + "/autopilot/status").then(r=>r.json()).then(setStatus);
+      }
+      function start() {
+        fetch(API_BASE + "/autopilot/start", {method:"POST"}).then(r=>r.json()).then(setStatus);
+      }
+      function stop() {
+        fetch(API_BASE + "/autopilot/stop", {method:"POST"}).then(r=>r.json()).then(setStatus);
+      }
+      function send() {
+        fetch(API_BASE + "/command", {
+          method: "POST",
           headers: {"Content-Type": "application/json"},
-          body: JSON.stringify({mode: select.value})
-        });
-      };
-
-      const risk = await (await fetch(API_BASE + "/risk/config")).json();
-      document.getElementById("risk-json").textContent = JSON.stringify(risk, null, 2);
-
-      const strats = await (await fetch(API_BASE + "/automation/strategies")).json();
-      const list = document.getElementById("strategy-list");
-      strats.forEach(s => {
-        const li = document.createElement("li");
-        li.textContent = s.name || ("strategy " + s.id);
-        list.appendChild(li);
-      });
-
-      const log = await (await fetch(API_BASE + "/logs/actions")).json();
-      document.getElementById("log-json").textContent = JSON.stringify(log, null, 2);
+          body: JSON.stringify({text: cmd})
+        }).then(r=>r.json()).then(r=>{setStatus(r); setMsg(JSON.stringify(r));});
+        setCmd("");
+      }
+      return e("section", null,
+        e("h2", null, "Autopilot"),
+        e("div", {className:"flex"},
+          e("span", null, "Status: " + (status.active ? "Active" : "Idle")),
+          e("button", {className:"primary", onClick:start, disabled: status.active}, "Start"),
+          e("button", {className:"primary", onClick:stop, disabled: !status.active}, "Stop")
+        ),
+        status.strategy && e("div", null, "Strategy: " + status.strategy),
+        status.last_command && e("div", null, "Last: " + status.last_command),
+        e("div", {className:"flex"},
+          e("input", {value: cmd, onChange: ev=>setCmd(ev.target.value), placeholder:"command"}),
+          e("button", {className:"primary", onClick: send}, "Send")
+        ),
+        msg && e("pre", null, msg)
+      );
     }
-    load();
+
+    function Backtest() {
+      const [symbol, setSymbol] = React.useState("US.AAPL");
+      const [fast, setFast] = React.useState(20);
+      const [slow, setSlow] = React.useState(50);
+      const [res, setRes] = React.useState(null);
+      function run() {
+        fetch(API_BASE + "/backtest/ma-crossover", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({symbol, fast:Number(fast), slow:Number(slow)})
+        }).then(r=>r.json()).then(setRes);
+      }
+      return e("section", null,
+        e("h2", null, "Backtest"),
+        e("div", {className:"flex"},
+          e("label", null, "Symbol"),
+          e("input", {value: symbol, onChange:e=>setSymbol(e.target.value)}),
+          e("label", null, "Fast"),
+          e("input", {type:"number", value: fast, onChange:e=>setFast(e.target.value)}),
+          e("label", null, "Slow"),
+          e("input", {type:"number", value: slow, onChange:e=>setSlow(e.target.value)}),
+          e("button", {className:"primary", onClick: run}, "Run")
+        ),
+        res && e("pre", null, JSON.stringify(res.metrics, null, 2))
+      );
+    }
+
+    function Settings() {
+      return e("section", null,
+        e("h2", null, "Settings"),
+        e("p", null, "Future controls go here")
+      );
+    }
+
+    function App() {
+      const [tab, setTab] = React.useState("dash");
+      return e("div", null,
+        e("nav", null,
+          e("button", {className: tab==='dash'?"active":"", onClick:()=>setTab('dash')}, "Dashboard"),
+          e("button", {className: tab==='bt'?"active":"", onClick:()=>setTab('bt')}, "Backtest"),
+          e("button", {className: tab==='settings'?"active":"", onClick:()=>setTab('settings')}, "Settings")
+        ),
+        tab==='dash' ? e(Dashboard) : tab==='bt' ? e(Backtest) : e(Settings)
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(e(App));
   </script>
 </body>
 </html>

--- a/src/autopilot.py
+++ b/src/autopilot.py
@@ -1,0 +1,35 @@
+"""Skeleton for autopilot mode."""
+from __future__ import annotations
+
+class Autopilot:
+    """Hold autopilot state."""
+
+    def __init__(self) -> None:
+        self.active = False
+        self.strategy = ""
+        self.last_command = ""
+
+    def start(self, strategy: str | None = None) -> None:
+        if strategy:
+            self.strategy = strategy
+        self.active = True
+        self.last_command = "started"
+
+    def stop(self) -> None:
+        self.active = False
+        self.last_command = "stopped"
+
+    def set_strategy(self, name: str) -> None:
+        self.strategy = name
+        self.last_command = f"strategy:{name}"
+
+    def tick(self) -> None:
+        """Run one cycle placeholder."""
+        self.last_command = "tick"
+
+    def status(self) -> dict:
+        return {
+            "active": self.active,
+            "strategy": self.strategy,
+            "last_command": self.last_command,
+        }

--- a/src/nlp.py
+++ b/src/nlp.py
@@ -1,0 +1,17 @@
+"""Map natural-language commands to actions."""
+from __future__ import annotations
+
+def parse_command(text: str) -> dict:
+    t = text.lower().strip()
+    if "start autopilot" in t:
+        return {"action": "start_autopilot"}
+    if "stop autopilot" in t:
+        return {"action": "stop_autopilot"}
+    if "run backtest" in t:
+        return {"action": "run_backtest"}
+    if t.startswith("set strategy"):
+        name = t.split("set strategy", 1)[1].strip()
+        return {"action": "set_strategy", "name": name}
+    if "status" in t:
+        return {"action": "status"}
+    return {"action": "unknown", "text": text}

--- a/src/server.py
+++ b/src/server.py
@@ -14,6 +14,8 @@ from core.moomoo_client import MoomooClient
 from core.futu_client import TrdEnv
 from core.session import load_session, save_session, clear_session
 from risk.limits import enforce_order_limits
+from autopilot import Autopilot
+from nlp import parse_command
 
 # Optional automation (scheduler + storage + strategy step)
 try:
@@ -79,6 +81,9 @@ client: Optional[MoomooClient] = None
 
 # Global scheduler (if automation imports are available)
 scheduler = None  # will hold TraderScheduler
+
+# Autopilot state holder
+autopilot = Autopilot()
 
 
 # ---------- Risk config (local file) ----------
@@ -215,6 +220,9 @@ class BotModeRequest(BaseModel):
 
 class FlattenAllRequest(BaseModel):
     symbols: Optional[list[str]] = None  # if provided, only flatten these symbols
+
+class CommandRequest(BaseModel):
+    text: str
 
 
 # ---------- Helpers ----------
@@ -667,6 +675,49 @@ def bot_mode_put(req: BotModeRequest):
     set_setting("bot_mode", mode)
     insert_action_log("mode_change", mode=mode, reason="user_update", status="ok")
     return {"mode": mode}
+
+
+# --- Autopilot ---
+
+class AutopilotStartRequest(BaseModel):
+    strategy: str | None = None
+
+
+@app.post("/autopilot/start")
+def autopilot_start(req: AutopilotStartRequest | None = None):
+    autopilot.start(req.strategy if req else None)
+    return autopilot.status()
+
+
+@app.post("/autopilot/stop")
+def autopilot_stop():
+    autopilot.stop()
+    return autopilot.status()
+
+
+@app.get("/autopilot/status")
+def autopilot_status():
+    return autopilot.status()
+
+
+@app.post("/command")
+def command(req: CommandRequest):
+    result = parse_command(req.text)
+    act = result.get("action")
+    if act == "start_autopilot":
+        autopilot.start()
+        return autopilot.status()
+    if act == "stop_autopilot":
+        autopilot.stop()
+        return autopilot.status()
+    if act == "run_backtest":
+        return {"status": "backtest_requested"}
+    if act == "set_strategy":
+        autopilot.set_strategy(result.get("name", ""))
+        return autopilot.status()
+    if act == "status":
+        return autopilot.status()
+    raise HTTPException(status_code=400, detail="unknown command")
 
 
 # --- Action Log API ---


### PR DESCRIPTION
## Summary
- extend Autopilot to track strategy and cycle placeholder
- add strategy and status handling in command parser and API
- polish React dashboard with start/stop controls, backtest form, and settings tab
- document updated features in README

## Testing
- `python -m py_compile src/autopilot.py src/nlp.py src/server.py desktop-ui/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a177c04b948326b3f5faca93f122ae